### PR TITLE
Release/Version1.2 - Framework update and code oriented to be used on IHost

### DIFF
--- a/src/IOLApiClient.Auth.Repository.Abstractions/IOLApiClient.Auth.Repository.Abstractions.csproj
+++ b/src/IOLApiClient.Auth.Repository.Abstractions/IOLApiClient.Auth.Repository.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageProjectUrl>https://github.com/Ryujose/InvertirOnline-API-Client</PackageProjectUrl>
@@ -18,8 +18,13 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Abstractions of Login method and data storage for bearer token data.</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated to .NET 5.0
+
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IOLApiClient.Auth.Repository/IOLApiClient.Auth.Repository.csproj
+++ b/src/IOLApiClient.Auth.Repository/IOLApiClient.Auth.Repository.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
@@ -17,12 +17,11 @@ To do these you've to create the account and enable the API product.</Descriptio
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Implementation of Login method and data storage for bearer token data</PackageReleaseNotes>
-  </PropertyGroup>
+    <PackageReleaseNotes>Updated to .NET 5.0
 
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-  </ItemGroup>
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <Version>2.0.0</Version>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\IOLApiClient.Auth.Repository.Abstractions\IOLApiClient.Auth.Repository.Abstractions.csproj" />
@@ -38,6 +37,10 @@ To do these you've to create the account and enable the API product.</Descriptio
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/IOLApiClient.Auth.Repository/Repositories/LoginRepository.cs
+++ b/src/IOLApiClient.Auth.Repository/Repositories/LoginRepository.cs
@@ -2,8 +2,7 @@
 using IOLApiClient.Auth.Repository.Abstractions.Interfaces;
 using IOLApiClient.Auth.Repository.Abstractions.Models;
 using IOLApiClient.DataStorage.Abstractions;
-using Serilog;
-using Serilog.Events;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -31,12 +30,12 @@ namespace IOLApiClient.Auth.Repository.Repositories
 
         private readonly ILoginRepositorySettings _loginRepositorySettings;
         private readonly IBearerTokenDataProvider _bearerTokenData;
-        private readonly ILogger _logger;
+        private readonly ILogger<LoginRepository> _logger;
 
         public LoginRepository(
             ILoginRepositorySettings loginRepositorySettings,
             IBearerTokenDataProvider bearerTokenData,
-            ILogger logger
+            ILogger<LoginRepository> logger
             )
         {
             _loginRepositorySettings = loginRepositorySettings;
@@ -49,7 +48,7 @@ namespace IOLApiClient.Auth.Repository.Repositories
         /// </summary>
         public async Task Login()
         {
-            _logger.Information($"{_classLogMessageDiagnose} {_methodLoginMessageDiagnose}, Initializing login...");
+            _logger.LogInformation($"{_classLogMessageDiagnose} {_methodLoginMessageDiagnose}, Initializing login...");
 
             if (string.IsNullOrEmpty(_loginRepositorySettings.UserNameIOLClient))
                 throw new InvalidOperationException($"{nameof(ILoginRepositorySettings.UserNameIOLClient)} is null or empty, can't login.");
@@ -70,13 +69,13 @@ namespace IOLApiClient.Auth.Repository.Repositories
 
                     var result = await client.PostAsync(BuildTokenURL(), content);
 
-                    _logger.Information($"{_classLogMessageDiagnose} {_methodLoginMessageDiagnose}, {(result != null ? $"Login result code: {result.StatusCode}" : "Login result is null")}");
+                    _logger.LogInformation($"{_classLogMessageDiagnose} {_methodLoginMessageDiagnose}, {(result != null ? $"Login result code: {result.StatusCode}" : "Login result is null")}");
 
                     result.EnsureSuccessStatusCode();
 
                     var loginResponseModel = await JsonSerializer.DeserializeAsync<LoginResponseModel>(await result.Content.ReadAsStreamAsync());
 
-                    _logger.Debug($"{_classLogMessageDiagnose} {_methodLoginMessageDiagnose}, login responde model deserialized");
+                    _logger.LogDebug($"{_classLogMessageDiagnose} {_methodLoginMessageDiagnose}, login responde model deserialized");
 
                     loginResponseModel.IssuedDateTime = Convert.ToDateTime(loginResponseModel.Issued);
                     loginResponseModel.RefreshExpiresDateTime = Convert.ToDateTime(loginResponseModel.RefreshExpires);
@@ -91,18 +90,18 @@ namespace IOLApiClient.Auth.Repository.Repositories
 
         private void LogLoginRespondeModel(LoginResponseModel loginResponseModel)
         {
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.Debug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.AccesToken)}: {loginResponseModel.AccesToken}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.Expires)}: {loginResponseModel.Expires}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.ExpiresDateTime)}: {loginResponseModel.ExpiresDateTime}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.ExpiresIn)}: {loginResponseModel.ExpiresIn}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.Issued)}: {loginResponseModel.Issued}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.IssuedDateTime)}: {loginResponseModel.IssuedDateTime}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.RefreshExpires)}: {loginResponseModel.RefreshExpires}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.RefreshExpiresDateTime)}: {loginResponseModel.RefreshExpiresDateTime}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.RefreshToken)}: {loginResponseModel.RefreshToken}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.TokenType)}: {loginResponseModel.TokenType}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.AccesToken)}: {loginResponseModel.AccesToken}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.Expires)}: {loginResponseModel.Expires}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.ExpiresDateTime)}: {loginResponseModel.ExpiresDateTime}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.ExpiresIn)}: {loginResponseModel.ExpiresIn}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.Issued)}: {loginResponseModel.Issued}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.IssuedDateTime)}: {loginResponseModel.IssuedDateTime}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.RefreshExpires)}: {loginResponseModel.RefreshExpires}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.RefreshExpiresDateTime)}: {loginResponseModel.RefreshExpiresDateTime}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.RefreshToken)}: {loginResponseModel.RefreshToken}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_methodLogLoginRespondeModelMessageDiagnose}, parameter {nameof(LoginResponseModel.TokenType)}: {loginResponseModel.TokenType}");
             }
         }
 
@@ -110,9 +109,9 @@ namespace IOLApiClient.Auth.Repository.Repositories
         {
             var tokenURL = $"{_loginRepositorySettings.BaseUrl}/token";
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.Debug($"{_classLogMessageDiagnose} {_methodBuildTokenURLMessageDiagnose}, tokenURL: {tokenURL}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_methodBuildTokenURLMessageDiagnose}, tokenURL: {tokenURL}");
             }
 
             return tokenURL;
@@ -123,7 +122,7 @@ namespace IOLApiClient.Auth.Repository.Repositories
             content.Headers.Clear();
             content.Headers.Add("Content-Type", "application/x-www-form-urlencoded");
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
                 foreach (var header in content.Headers)
                 {
@@ -131,7 +130,7 @@ namespace IOLApiClient.Auth.Repository.Repositories
 
                     foreach (var value in values)
                     {
-                        _logger.Debug($"{_classLogMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, content header assigned key: {header.Key}, value: {value}");
+                        _logger.LogDebug($"{_classLogMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, content header assigned key: {header.Key}, value: {value}");
                     }
                 }
             }
@@ -146,11 +145,11 @@ namespace IOLApiClient.Auth.Repository.Repositories
                 { _GRANT_TYPE_POST_KEY, _GRANT_TYPE_LOGIN_POST_VALUE }
             };
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
                 foreach (var item in result)
                 {
-                    _logger.Debug($"{_classLogMessageDiagnose} {_methodBuildLoginPostParametersMessageDiagnose}, parameters post key: {item.Key}, value: {item.Value}");
+                    _logger.LogDebug($"{_classLogMessageDiagnose} {_methodBuildLoginPostParametersMessageDiagnose}, parameters post key: {item.Key}, value: {item.Value}");
                 }
             }
 
@@ -166,7 +165,7 @@ namespace IOLApiClient.Auth.Repository.Repositories
             client.DefaultRequestHeaders.Add("Cache-Control", "no-cache");
             client.DefaultRequestHeaders.Add("Accept-Encoding", "gzip, deflate, br");
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
                 foreach (var defaultRequestHeader in client.DefaultRequestHeaders)
                 {
@@ -174,7 +173,7 @@ namespace IOLApiClient.Auth.Repository.Repositories
 
                     foreach (var value in values)
                     {
-                        _logger.Debug($"{_classLogMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, default header assigned key: {defaultRequestHeader.Key}, value: {value}");
+                        _logger.LogDebug($"{_classLogMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, default header assigned key: {defaultRequestHeader.Key}, value: {value}");
                     }
                 }
             }

--- a/src/IOLApiClient.Communication.Abstractions/IOLApiClient.Communication.Abstractions.csproj
+++ b/src/IOLApiClient.Communication.Abstractions/IOLApiClient.Communication.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
@@ -17,7 +17,10 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Abstractions of communication objects</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated to .NET 5.0
+
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IOLApiClient.DataStorage.Abstractions/IOLApiClient.DataStorage.Abstractions.csproj
+++ b/src/IOLApiClient.DataStorage.Abstractions/IOLApiClient.DataStorage.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageProjectUrl>https://github.com/Ryujose/InvertirOnline-API-Client</PackageProjectUrl>
@@ -16,8 +16,11 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Abastractions of BearerTokenData</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated to .NET 5.0
+
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IOLApiClient.DataStorage/BearerTokenData.cs
+++ b/src/IOLApiClient.DataStorage/BearerTokenData.cs
@@ -1,7 +1,6 @@
 ﻿using IOLApiClient.Auth.Repository.Abstractions.Models;
 using IOLApiClient.DataStorage.Abstractions;
-using Serilog;
-using Serilog.Events;
+using Microsoft.Extensions.Logging;
 
 namespace IOLApiClient.DataStorage
 {
@@ -11,8 +10,8 @@ namespace IOLApiClient.DataStorage
         static string _propertyLoginMessageDiagnose = $"Property: {nameof(LoginResponseModel)}";
 
 
-        private readonly ILogger _logger;
-        public BearerTokenData(ILogger logger)
+        private readonly ILogger<BearerTokenData> _logger;
+        public BearerTokenData(ILogger<BearerTokenData> logger)
         {
             _logger = logger;
         }
@@ -37,27 +36,27 @@ namespace IOLApiClient.DataStorage
 
         private void LogLoginRespondeModel(LoginResponseModel loginResponseModel, string getSetNotification)
         {
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.Debug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, property notification: {getSetNotification}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, property notification: {getSetNotification}");
 
                 if (loginResponseModel == null)
                 {
-                    _logger.Debug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, loginRespondeModel: is null");
+                    _logger.LogDebug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, loginRespondeModel: is null");
 
                     return;
                 }
 
-                _logger.Debug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.AccesToken)}: {loginResponseModel.AccesToken}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.Expires)}: {loginResponseModel.Expires}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.ExpiresDateTime)}: {loginResponseModel.ExpiresDateTime}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.ExpiresIn)}: {loginResponseModel.ExpiresIn}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.Issued)}: {loginResponseModel.Issued}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.IssuedDateTime)}: {loginResponseModel.IssuedDateTime}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.RefreshExpires)}: {loginResponseModel.RefreshExpires}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.RefreshExpiresDateTime)}: {loginResponseModel.RefreshExpiresDateTime}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.RefreshToken)}: {loginResponseModel.RefreshToken}");
-                _logger.Debug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.TokenType)}: {loginResponseModel.TokenType}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.AccesToken)}: {loginResponseModel.AccesToken}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.Expires)}: {loginResponseModel.Expires}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.ExpiresDateTime)}: {loginResponseModel.ExpiresDateTime}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.ExpiresIn)}: {loginResponseModel.ExpiresIn}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.Issued)}: {loginResponseModel.Issued}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.IssuedDateTime)}: {loginResponseModel.IssuedDateTime}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.RefreshExpires)}: {loginResponseModel.RefreshExpires}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.RefreshExpiresDateTime)}: {loginResponseModel.RefreshExpiresDateTime}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.RefreshToken)}: {loginResponseModel.RefreshToken}");
+                _logger.LogDebug($"{_classLogMessageDiagnose} {_propertyLoginMessageDiagnose}, parameter {nameof(LoginResponseModel.TokenType)}: {loginResponseModel.TokenType}");
             }
         }
 

--- a/src/IOLApiClient.DataStorage/IOLApiClient.DataStorage.csproj
+++ b/src/IOLApiClient.DataStorage/IOLApiClient.DataStorage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageProjectUrl>https://github.com/Ryujose/InvertirOnline-API-Client</PackageProjectUrl>
@@ -16,13 +16,14 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Implementation of BearerTokenData in memory</PackageReleaseNotes>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-  </PropertyGroup>
+    <PackageReleaseNotes>Updated to .NET 5.0
 
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-  </ItemGroup>
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+    <Version>2.0.0</Version>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\IOLApiClient.DataStorage.Abstractions\IOLApiClient.DataStorage.Abstractions.csproj" />
@@ -38,6 +39,10 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/IOLApiClient.Example.Presentation.Abstractions/IOLApiClient.Example.Presentation.Abstractions.csproj
+++ b/src/IOLApiClient.Example.Presentation.Abstractions/IOLApiClient.Example.Presentation.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IOLApiClient.Example.Presentation/IOLApiClient.Example.Presentation.csproj
+++ b/src/IOLApiClient.Example.Presentation/IOLApiClient.Example.Presentation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>IOLApiClient.Example.Presentation</AssemblyName>
     <RootNamespace>IOLApiClient.Example.Presentation</RootNamespace>
   </PropertyGroup>

--- a/src/IOLApiClient.MyAccount.AccountStatus.Repository.Abstractions/IOLApiClient.MyAccount.AccountStatus.Repository.Abstractions.csproj
+++ b/src/IOLApiClient.MyAccount.AccountStatus.Repository.Abstractions/IOLApiClient.MyAccount.AccountStatus.Repository.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/IOLApiClient.MyAccount.AccountStatus.Repository/IOLApiClient.MyAccount.AccountStatus.Repository.csproj
+++ b/src/IOLApiClient.MyAccount.AccountStatus.Repository/IOLApiClient.MyAccount.AccountStatus.Repository.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/IOLApiClient.MyAccount.Operations.Repository.Abstractions/IOLApiClient.MyAccount.Operations.Repository.Abstractions.csproj
+++ b/src/IOLApiClient.MyAccount.Operations.Repository.Abstractions/IOLApiClient.MyAccount.Operations.Repository.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
@@ -19,7 +19,10 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Abstractions of operational delete and retrieval of transaction</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated to .NET 5.0
+
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IOLApiClient.MyAccount.Operations.Repository/IOLApiClient.MyAccount.Operations.Repository.csproj
+++ b/src/IOLApiClient.MyAccount.Operations.Repository/IOLApiClient.MyAccount.Operations.Repository.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
@@ -19,12 +19,11 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Implementation of operational delete and retrieval of transaction</PackageReleaseNotes>
-  </PropertyGroup>
+    <PackageReleaseNotes>Updated to .NET 5.0
 
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-  </ItemGroup>
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <Version>2.0.0</Version>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\IOLApiClient.Communication.Abstractions\IOLApiClient.Communication.Abstractions.csproj" />
@@ -41,6 +40,10 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/IOLApiClient.MyAccount.Operations.Repository/Repositories/V2/OperationsRepository.cs
+++ b/src/IOLApiClient.MyAccount.Operations.Repository/Repositories/V2/OperationsRepository.cs
@@ -3,8 +3,7 @@ using IOLApiClient.Communication.Abstractions.Models;
 using IOLApiClient.Communication.Abstractions.Models.Interfaces;
 using IOLApiClient.DataStorage.Abstractions;
 using IOLApiClient.MyAccount.Operations.Repository.Abstractions.Interfaces.V2;
-using Serilog;
-using Serilog.Events;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -24,12 +23,12 @@ namespace IOLApiClient.MyAccount.Operations.Repository.Repositories.V2
         static string _methodBuildObtainOperationTransactionURLURLMessageDiagnose = $"Method: {nameof(BuildGetTransactionURL)}";
 
         private readonly IBearerTokenDataProvider _bearerTokenDataProvider;
-        private readonly ILogger _logger;
+        private readonly ILogger<OperationsRepository> _logger;
         private readonly ILoginRepositorySettings _loginRepositorySettings;
 
         public OperationsRepository(
             IBearerTokenDataProvider bearerTokenDataProvider,
-            ILogger logger,
+            ILogger<OperationsRepository> logger,
             ILoginRepositorySettings loginRepositorySettings)
         {
             _bearerTokenDataProvider = bearerTokenDataProvider;
@@ -43,7 +42,7 @@ namespace IOLApiClient.MyAccount.Operations.Repository.Repositories.V2
             {
                 BuildDefaultHeaders(client);
 
-                _logger.Information($"{_classOperationsRepositoryMessageDiagnose} {_methodDeleteTransactionMessageDiagnose}, Initializing GetTransaction...");
+                _logger.LogInformation($"{_classOperationsRepositoryMessageDiagnose} {_methodDeleteTransactionMessageDiagnose}, Initializing GetTransaction...");
 
                 if (_bearerTokenDataProvider.LoginResponseModel == null)
                     throw new InvalidOperationException($"{nameof(IBearerTokenDataProvider.LoginResponseModel)} is null, can't get transaction.");
@@ -55,7 +54,7 @@ namespace IOLApiClient.MyAccount.Operations.Repository.Repositories.V2
                 {
                     var result = await client.GetAsync(BuildGetTransactionURL(transactionId));
 
-                    _logger.Information($"{_classOperationsRepositoryMessageDiagnose} {_methodDeleteTransactionMessageDiagnose}, {(result != null ? $"get transaction result code: {result.StatusCode}" : "get transaction is null")}");
+                    _logger.LogInformation($"{_classOperationsRepositoryMessageDiagnose} {_methodDeleteTransactionMessageDiagnose}, {(result != null ? $"get transaction result code: {result.StatusCode}" : "get transaction is null")}");
 
                     result.EnsureSuccessStatusCode();
 
@@ -85,7 +84,7 @@ namespace IOLApiClient.MyAccount.Operations.Repository.Repositories.V2
             {
                 BuildDefaultHeaders(client);
 
-                _logger.Information($"{_classOperationsRepositoryMessageDiagnose} {_methodDeleteTransactionMessageDiagnose}, Initializing DeleteTransaction...");
+                _logger.LogInformation($"{_classOperationsRepositoryMessageDiagnose} {_methodDeleteTransactionMessageDiagnose}, Initializing DeleteTransaction...");
 
                 if (_bearerTokenDataProvider.LoginResponseModel == null)
                     throw new InvalidOperationException($"{nameof(IBearerTokenDataProvider.LoginResponseModel)} is null, can't delete transaction.");
@@ -95,7 +94,7 @@ namespace IOLApiClient.MyAccount.Operations.Repository.Repositories.V2
 
                 var result = await client.DeleteAsync(BuildOperationsDeleteTransactionURL(transactionId));
 
-                _logger.Information($"{_classOperationsRepositoryMessageDiagnose} {_methodDeleteTransactionMessageDiagnose}, {(result != null ? $"delete transaction result code: {result.StatusCode}" : "delete transaction is null")}");
+                _logger.LogInformation($"{_classOperationsRepositoryMessageDiagnose} {_methodDeleteTransactionMessageDiagnose}, {(result != null ? $"delete transaction result code: {result.StatusCode}" : "delete transaction is null")}");
 
                 result.EnsureSuccessStatusCode();
 
@@ -118,9 +117,9 @@ namespace IOLApiClient.MyAccount.Operations.Repository.Repositories.V2
         {
             var BuildOperationsDeleteURL = $"{_loginRepositorySettings.BaseUrl}/api/v2/operaciones/{transactionID}";
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.Debug($"{_classOperationsRepositoryMessageDiagnose} {_methodOperationsDeleteTransactionURLMessageDiagnose}, BuildOperationsDeleteURL: {BuildOperationsDeleteURL}");
+                _logger.LogDebug($"{_classOperationsRepositoryMessageDiagnose} {_methodOperationsDeleteTransactionURLMessageDiagnose}, BuildOperationsDeleteURL: {BuildOperationsDeleteURL}");
             }
 
             return BuildOperationsDeleteURL;
@@ -130,9 +129,9 @@ namespace IOLApiClient.MyAccount.Operations.Repository.Repositories.V2
         {
             var BuildGetTransactionURL = $"{_loginRepositorySettings.BaseUrl}/api/v2/operaciones/{transactionID}";
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.Debug($"{_classOperationsRepositoryMessageDiagnose} {_methodBuildObtainOperationTransactionURLURLMessageDiagnose}, BuildGetTransactionURL: {BuildGetTransactionURL}");
+                _logger.LogDebug($"{_classOperationsRepositoryMessageDiagnose} {_methodBuildObtainOperationTransactionURLURLMessageDiagnose}, BuildGetTransactionURL: {BuildGetTransactionURL}");
             }
 
             return BuildGetTransactionURL;
@@ -148,7 +147,7 @@ namespace IOLApiClient.MyAccount.Operations.Repository.Repositories.V2
             client.DefaultRequestHeaders.Add("Cache-Control", "no-cache");
             client.DefaultRequestHeaders.Add("Accept-Encoding", "gzip, deflate, br");
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
                 foreach (var defaultRequestHeader in client.DefaultRequestHeaders)
                 {
@@ -156,7 +155,7 @@ namespace IOLApiClient.MyAccount.Operations.Repository.Repositories.V2
 
                     foreach (var value in values)
                     {
-                        _logger.Debug($"{_classOperationsRepositoryMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, default header assigned key: {defaultRequestHeader.Key}, value: {value}");
+                        _logger.LogDebug($"{_classOperationsRepositoryMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, default header assigned key: {defaultRequestHeader.Key}, value: {value}");
                     }
                 }
             }

--- a/src/IOLApiClient.MyAccount.Portfolio.Repository.Abstractions/IOLApiClient.MyAccount.Portfolio.Repository.Abstractions.csproj
+++ b/src/IOLApiClient.MyAccount.Portfolio.Repository.Abstractions/IOLApiClient.MyAccount.Portfolio.Repository.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/IOLApiClient.MyAccount.Portfolio.Repository/IOLApiClient.MyAccount.Portfolio.Repository.csproj
+++ b/src/IOLApiClient.MyAccount.Portfolio.Repository/IOLApiClient.MyAccount.Portfolio.Repository.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/IOLApiClient.Operative.Abstractions/IOLApiClient.Operative.Abstractions.csproj
+++ b/src/IOLApiClient.Operative.Abstractions/IOLApiClient.Operative.Abstractions.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
@@ -17,7 +17,10 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Abstractions of operatiove data</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated to .NET 5.0
+
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IOLApiClient.Operative.Buy.Repository.Abstractions/IOLApiClient.Operative.Buy.Repository.Abstractions.csproj
+++ b/src/IOLApiClient.Operative.Buy.Repository.Abstractions/IOLApiClient.Operative.Buy.Repository.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
@@ -19,7 +19,10 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Abstractions of buy stocks</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated to .NET 5.0
+
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IOLApiClient.Operative.Buy.Repository/IOLApiClient.Operative.Buy.Repository.csproj
+++ b/src/IOLApiClient.Operative.Buy.Repository/IOLApiClient.Operative.Buy.Repository.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
@@ -19,12 +19,11 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Implementation of buy stocks</PackageReleaseNotes>
-  </PropertyGroup>
+    <PackageReleaseNotes>Updated to .NET 5.0
 
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-  </ItemGroup>
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <Version>2.0.0</Version>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\IOLApiClient.Communication.Abstractions\IOLApiClient.Communication.Abstractions.csproj" />
@@ -41,5 +40,8 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/IOLApiClient.Operative.Buy.Repository/Repositories/V2/BuyRepository.cs
+++ b/src/IOLApiClient.Operative.Buy.Repository/Repositories/V2/BuyRepository.cs
@@ -4,8 +4,7 @@ using IOLApiClient.Communication.Abstractions.Models.Interfaces;
 using IOLApiClient.DataStorage.Abstractions;
 using IOLApiClient.Operative.Abstractions.Models;
 using IOLApiClient.Operative.Buy.Repository.Abstractions.Interfaces.V2;
-using Serilog;
-using Serilog.Events;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -25,12 +24,12 @@ namespace IOLApiClient.Operative.Buy.Repository.Repositories.V2
         static string _methodBuildBuyURLMessageDiagnose = $"Method: {nameof(BuildBuyURL)}";
 
         private readonly IBearerTokenDataProvider _bearerTokenDataProvider;
-        private readonly ILogger _logger;
+        private readonly ILogger<BuyRepository> _logger;
         private readonly ILoginRepositorySettings _loginRepositorySettings;
 
         public BuyRepository(
             IBearerTokenDataProvider bearerTokenDataProvider,
-            ILogger logger,
+            ILogger<BuyRepository> logger,
             ILoginRepositorySettings loginRepositorySettings)
         {
             _bearerTokenDataProvider = bearerTokenDataProvider;
@@ -44,7 +43,7 @@ namespace IOLApiClient.Operative.Buy.Repository.Repositories.V2
             {
                 BuildDefaultHeaders(client);
 
-                _logger.Information($"{_classBuyRepositoryMessageDiagnose} {_methodBuyMessageDiagnose}, Initializing buy...");
+                _logger.LogInformation($"{_classBuyRepositoryMessageDiagnose} {_methodBuyMessageDiagnose}, Initializing buy...");
 
                 if (_bearerTokenDataProvider.LoginResponseModel == null)
                     throw new InvalidOperationException($"{nameof(IBearerTokenDataProvider.LoginResponseModel)} is null, can't buy.");
@@ -57,7 +56,7 @@ namespace IOLApiClient.Operative.Buy.Repository.Repositories.V2
                 {
                     var result = await client.PostAsync(BuildBuyURL(), content);
 
-                    _logger.Information($"{_classBuyRepositoryMessageDiagnose} {_methodBuyMessageDiagnose}, {(result != null ? $"Buy result code: {result.StatusCode}" : "Buy is null")}");
+                    _logger.LogInformation($"{_classBuyRepositoryMessageDiagnose} {_methodBuyMessageDiagnose}, {(result != null ? $"Buy result code: {result.StatusCode}" : "Buy is null")}");
 
                     result.EnsureSuccessStatusCode();
 
@@ -97,9 +96,9 @@ namespace IOLApiClient.Operative.Buy.Repository.Repositories.V2
         {
             var buyURL = $"{_loginRepositorySettings.BaseUrl}/api/v2/operar/Comprar";
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.Debug($"{_classBuyRepositoryMessageDiagnose} {_methodBuildBuyURLMessageDiagnose}, BuildBuyURL: {buyURL}");
+                _logger.LogDebug($"{_classBuyRepositoryMessageDiagnose} {_methodBuildBuyURLMessageDiagnose}, BuildBuyURL: {buyURL}");
             }
 
             return buyURL;
@@ -115,7 +114,7 @@ namespace IOLApiClient.Operative.Buy.Repository.Repositories.V2
             client.DefaultRequestHeaders.Add("Cache-Control", "no-cache");
             client.DefaultRequestHeaders.Add("Accept-Encoding", "gzip, deflate, br");
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
                 foreach (var defaultRequestHeader in client.DefaultRequestHeaders)
                 {
@@ -123,7 +122,7 @@ namespace IOLApiClient.Operative.Buy.Repository.Repositories.V2
 
                     foreach (var value in values)
                     {
-                        _logger.Debug($"{_classBuyRepositoryMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, default header assigned key: {defaultRequestHeader.Key}, value: {value}");
+                        _logger.LogDebug($"{_classBuyRepositoryMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, default header assigned key: {defaultRequestHeader.Key}, value: {value}");
                     }
                 }
             }

--- a/src/IOLApiClient.Operative.Retrieval.Repository.Abstractions/IOLApiClient.Operative.Retrieval.Repository.Abstractions.csproj
+++ b/src/IOLApiClient.Operative.Retrieval.Repository.Abstractions/IOLApiClient.Operative.Retrieval.Repository.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
@@ -19,7 +19,12 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Abstractions of retrieval from a subscription</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated to .NET 5.0
+
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IOLApiClient.Operative.Retrieval.Repository/IOLApiClient.Operative.Retrieval.Repository.csproj
+++ b/src/IOLApiClient.Operative.Retrieval.Repository/IOLApiClient.Operative.Retrieval.Repository.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
@@ -19,12 +19,11 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Implementation of retrieval from a subscription</PackageReleaseNotes>
-  </PropertyGroup>
+    <PackageReleaseNotes>Updated to .NET 5.0
 
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-  </ItemGroup>
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <Version>2.0.0</Version>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\IOLApiClient.DataStorage.Abstractions\IOLApiClient.DataStorage.Abstractions.csproj" />
@@ -41,4 +40,8 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
+
+<ItemGroup>
+  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+</ItemGroup>
 </Project>

--- a/src/IOLApiClient.Operative.Retrieval.Repository/Repositories/V2/RetrievalRepository.cs
+++ b/src/IOLApiClient.Operative.Retrieval.Repository/Repositories/V2/RetrievalRepository.cs
@@ -4,8 +4,7 @@ using IOLApiClient.Communication.Abstractions.Models.Interfaces;
 using IOLApiClient.DataStorage.Abstractions;
 using IOLApiClient.Operative.Abstractions.Models;
 using IOLApiClient.Operative.Retrieval.Repository.Abstractions.Interfaces.V2;
-using Serilog;
-using Serilog.Events;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -25,12 +24,12 @@ namespace IOLApiClient.Operative.Retrieval.Repository.Repositories.V2
         static string _methodBuildRetrieveURLMessageDiagnose = $"Method: {nameof(BuildRetrieveURL)}";
 
         private readonly IBearerTokenDataProvider _bearerTokenDataProvider;
-        private readonly ILogger _logger;
+        private readonly ILogger<RetrievalRepository> _logger;
         private readonly ILoginRepositorySettings _loginRepositorySettings;
 
         public RetrievalRepository(
             IBearerTokenDataProvider bearerTokenDataProvider,
-            ILogger logger,
+            ILogger<RetrievalRepository> logger,
             ILoginRepositorySettings loginRepositorySettings)
         {
             _bearerTokenDataProvider = bearerTokenDataProvider;
@@ -44,7 +43,7 @@ namespace IOLApiClient.Operative.Retrieval.Repository.Repositories.V2
             {
                 BuildDefaultHeaders(client);
 
-                _logger.Information($"{_classRetrievalRepositoryMessageDiagnose} {_methodRetrieveFCIMessageDiagnose}, Initializing retrieval...");
+                _logger.LogInformation($"{_classRetrievalRepositoryMessageDiagnose} {_methodRetrieveFCIMessageDiagnose}, Initializing retrieval...");
 
                 if (_bearerTokenDataProvider.LoginResponseModel == null)
                     throw new InvalidOperationException($"{nameof(IBearerTokenDataProvider.LoginResponseModel)} is null, can't retrieve.");
@@ -57,7 +56,7 @@ namespace IOLApiClient.Operative.Retrieval.Repository.Repositories.V2
                 {
                     var result = await client.PostAsync(BuildRetrieveURL(), content);
 
-                    _logger.Information($"{_classRetrievalRepositoryMessageDiagnose} {_methodRetrieveFCIMessageDiagnose}, {(result != null ? $"Retrieve result code: {result.StatusCode}" : "Retrieve is null")}");
+                    _logger.LogInformation($"{_classRetrievalRepositoryMessageDiagnose} {_methodRetrieveFCIMessageDiagnose}, {(result != null ? $"Retrieve result code: {result.StatusCode}" : "Retrieve is null")}");
 
                     result.EnsureSuccessStatusCode();
 
@@ -98,9 +97,9 @@ namespace IOLApiClient.Operative.Retrieval.Repository.Repositories.V2
         {
             var retrieveURL = $"{_loginRepositorySettings.BaseUrl}/api/v2/operar/Rescate/fci";
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.Debug($"{_classRetrievalRepositoryMessageDiagnose} {_methodBuildRetrieveURLMessageDiagnose}, retrieveURL: {retrieveURL}");
+                _logger.LogDebug($"{_classRetrievalRepositoryMessageDiagnose} {_methodBuildRetrieveURLMessageDiagnose}, retrieveURL: {retrieveURL}");
             }
 
             return retrieveURL;
@@ -116,7 +115,7 @@ namespace IOLApiClient.Operative.Retrieval.Repository.Repositories.V2
             client.DefaultRequestHeaders.Add("Cache-Control", "no-cache");
             client.DefaultRequestHeaders.Add("Accept-Encoding", "gzip, deflate, br");
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
                 foreach (var defaultRequestHeader in client.DefaultRequestHeaders)
                 {
@@ -124,7 +123,7 @@ namespace IOLApiClient.Operative.Retrieval.Repository.Repositories.V2
 
                     foreach (var value in values)
                     {
-                        _logger.Debug($"{_classRetrievalRepositoryMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, default header assigned key: {defaultRequestHeader.Key}, value: {value}");
+                        _logger.LogDebug($"{_classRetrievalRepositoryMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, default header assigned key: {defaultRequestHeader.Key}, value: {value}");
                     }
                 }
             }

--- a/src/IOLApiClient.Operative.Sell.Repository.Abstractions/IOLApiClient.Operative.Sell.Repository.Abstractions.csproj
+++ b/src/IOLApiClient.Operative.Sell.Repository.Abstractions/IOLApiClient.Operative.Sell.Repository.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
@@ -19,7 +19,10 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Abstractions of sell an stock</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated to .NET 5.0
+
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IOLApiClient.Operative.Sell.Repository/IOLApiClient.Operative.Sell.Repository.csproj
+++ b/src/IOLApiClient.Operative.Sell.Repository/IOLApiClient.Operative.Sell.Repository.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
@@ -19,12 +19,11 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Implementation of sell an stock</PackageReleaseNotes>
-  </PropertyGroup>
+    <PackageReleaseNotes>Updated to .NET 5.0
 
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-  </ItemGroup>
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <Version>2.0.0</Version>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\IOLApiClient.Communication.Abstractions\IOLApiClient.Communication.Abstractions.csproj" />
@@ -42,5 +41,9 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/IOLApiClient.Operative.Sell.Repository/Repositories/V2/SellRepository.cs
+++ b/src/IOLApiClient.Operative.Sell.Repository/Repositories/V2/SellRepository.cs
@@ -4,8 +4,7 @@ using IOLApiClient.Communication.Abstractions.Models.Interfaces;
 using IOLApiClient.DataStorage.Abstractions;
 using IOLApiClient.Operative.Abstractions.Models;
 using IOLApiClient.Operative.Sell.Repository.Abstractions.Interfaces.V2;
-using Serilog;
-using Serilog.Events;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -25,12 +24,12 @@ namespace IOLApiClient.Operative.Sell.Repository.Repositories.V2
         static string _methodBuildSellURLMessageDiagnose = $"Method: {nameof(BuildSellURL)}";
 
         private readonly IBearerTokenDataProvider _bearerTokenDataProvider;
-        private readonly ILogger _logger;
+        private readonly ILogger<SellRepository> _logger;
         private readonly ILoginRepositorySettings _loginRepositorySettings;
 
         public SellRepository(
             IBearerTokenDataProvider bearerTokenDataProvider,
-            ILogger logger,
+            ILogger<SellRepository> logger,
             ILoginRepositorySettings loginRepositorySettings)
         {
             _bearerTokenDataProvider = bearerTokenDataProvider;
@@ -44,7 +43,7 @@ namespace IOLApiClient.Operative.Sell.Repository.Repositories.V2
             {
                 BuildDefaultHeaders(client);
 
-                _logger.Information($"{_classSellRepositoryMessageDiagnose} {_methodBuyMessageDiagnose}, Initializing sell...");
+                _logger.LogInformation($"{_classSellRepositoryMessageDiagnose} {_methodBuyMessageDiagnose}, Initializing sell...");
 
                 if (_bearerTokenDataProvider.LoginResponseModel == null)
                     throw new InvalidOperationException($"{nameof(IBearerTokenDataProvider.LoginResponseModel)} is null, can't sell.");
@@ -57,7 +56,7 @@ namespace IOLApiClient.Operative.Sell.Repository.Repositories.V2
                 {
                     var result = await client.PostAsync(BuildSellURL(), content);
 
-                    _logger.Information($"{_classSellRepositoryMessageDiagnose} {_methodBuyMessageDiagnose}, {(result != null ? $"Sell result code: {result.StatusCode}" : "Sell is null")}");
+                    _logger.LogInformation($"{_classSellRepositoryMessageDiagnose} {_methodBuyMessageDiagnose}, {(result != null ? $"Sell result code: {result.StatusCode}" : "Sell is null")}");
 
                     result.EnsureSuccessStatusCode();
 
@@ -104,9 +103,9 @@ namespace IOLApiClient.Operative.Sell.Repository.Repositories.V2
         {
             var buyURL = $"{_loginRepositorySettings.BaseUrl}/api/v2/operar/Vender";
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.Debug($"{_classSellRepositoryMessageDiagnose} {_methodBuildSellURLMessageDiagnose}, BuildSellURL: {buyURL}");
+                _logger.LogDebug($"{_classSellRepositoryMessageDiagnose} {_methodBuildSellURLMessageDiagnose}, BuildSellURL: {buyURL}");
             }
 
             return buyURL;
@@ -122,7 +121,7 @@ namespace IOLApiClient.Operative.Sell.Repository.Repositories.V2
             client.DefaultRequestHeaders.Add("Cache-Control", "no-cache");
             client.DefaultRequestHeaders.Add("Accept-Encoding", "gzip, deflate, br");
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
                 foreach (var defaultRequestHeader in client.DefaultRequestHeaders)
                 {
@@ -130,7 +129,7 @@ namespace IOLApiClient.Operative.Sell.Repository.Repositories.V2
 
                     foreach (var value in values)
                     {
-                        _logger.Debug($"{_classSellRepositoryMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, default header assigned key: {defaultRequestHeader.Key}, value: {value}");
+                        _logger.LogDebug($"{_classSellRepositoryMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, default header assigned key: {defaultRequestHeader.Key}, value: {value}");
                     }
                 }
             }

--- a/src/IOLApiClient.Operative.Subscription.Repository.Abstractions/IOLApiClient.Operative.Subscription.Repository.Abstractions.csproj
+++ b/src/IOLApiClient.Operative.Subscription.Repository.Abstractions/IOLApiClient.Operative.Subscription.Repository.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
@@ -19,7 +19,10 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Abstraction of subscription</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated to .NET 5.0
+
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IOLApiClient.Operative.Subscription.Repository/IOLApiClient.Operative.Subscription.Repository.csproj
+++ b/src/IOLApiClient.Operative.Subscription.Repository/IOLApiClient.Operative.Subscription.Repository.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>MIT License - Copyright (c) 2020 Jose Luis Guerra Infante</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
@@ -19,12 +19,11 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>OpenSource</RepositoryType>
     <RepositoryUrl>https://github.com/Ryujose/InvertirOnline-API-Client</RepositoryUrl>
-    <PackageReleaseNotes>Implementation of subscription</PackageReleaseNotes>
-  </PropertyGroup>
+    <PackageReleaseNotes>Updated to .NET 5.0
 
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-  </ItemGroup>
+Use of .NET extension ILogger instead of serilog</PackageReleaseNotes>
+    <Version>2.0.0</Version>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\IOLApiClient.Communication.Abstractions\IOLApiClient.Communication.Abstractions.csproj" />
@@ -42,5 +41,9 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/IOLApiClient.Operative.Subscription.Repository/Repositories/V2/SubscriptionRepository.cs
+++ b/src/IOLApiClient.Operative.Subscription.Repository/Repositories/V2/SubscriptionRepository.cs
@@ -4,8 +4,7 @@ using IOLApiClient.Communication.Abstractions.Models.Interfaces;
 using IOLApiClient.DataStorage.Abstractions;
 using IOLApiClient.Operative.Abstractions.Models;
 using IOLApiClient.Operative.Subscription.Repository.Abstractions.Interfaces.V2;
-using Serilog;
-using Serilog.Events;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -25,12 +24,12 @@ namespace IOLApiClient.Operative.Subscription.Repository.Repositories.V2
         static string _methodBuildSubscriptionURLMessageDiagnose = $"Method: {nameof(BuildSubscriptionURL)}";
 
         private readonly IBearerTokenDataProvider _bearerTokenDataProvider;
-        private readonly ILogger _logger;
+        private readonly ILogger<SubscriptionRepository> _logger;
         private readonly ILoginRepositorySettings _loginRepositorySettings;
 
         public SubscriptionRepository(
             IBearerTokenDataProvider bearerTokenDataProvider,
-            ILogger logger,
+            ILogger<SubscriptionRepository> logger,
             ILoginRepositorySettings loginRepositorySettings)
         {
             _bearerTokenDataProvider = bearerTokenDataProvider;
@@ -44,7 +43,7 @@ namespace IOLApiClient.Operative.Subscription.Repository.Repositories.V2
             {
                 BuildDefaultHeaders(client);
 
-                _logger.Information($"{_classSubscriptionRepositoryMessageDiagnose} {_methodSubscribeFCIMessageDiagnose}, Initializing subscription...");
+                _logger.LogInformation($"{_classSubscriptionRepositoryMessageDiagnose} {_methodSubscribeFCIMessageDiagnose}, Initializing subscription...");
 
                 if (_bearerTokenDataProvider.LoginResponseModel == null)
                     throw new InvalidOperationException($"{nameof(IBearerTokenDataProvider.LoginResponseModel)} is null, can't subscribe.");
@@ -57,7 +56,7 @@ namespace IOLApiClient.Operative.Subscription.Repository.Repositories.V2
                 {
                     var result = await client.PostAsync(BuildSubscriptionURL(), content);
 
-                    _logger.Information($"{_classSubscriptionRepositoryMessageDiagnose} {_methodSubscribeFCIMessageDiagnose}, {(result != null ? $"Subscribe result code: {result.StatusCode}" : "Subscribe is null")}");
+                    _logger.LogInformation($"{_classSubscriptionRepositoryMessageDiagnose} {_methodSubscribeFCIMessageDiagnose}, {(result != null ? $"Subscribe result code: {result.StatusCode}" : "Subscribe is null")}");
 
                     result.EnsureSuccessStatusCode();
 
@@ -98,9 +97,9 @@ namespace IOLApiClient.Operative.Subscription.Repository.Repositories.V2
         {
             var subscriptionURL = $"{_loginRepositorySettings.BaseUrl}/api/v2/operar/Suscripcion/fci";
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.Debug($"{_classSubscriptionRepositoryMessageDiagnose} {_methodBuildSubscriptionURLMessageDiagnose}, subscriptionURL: {subscriptionURL}");
+                _logger.LogDebug($"{_classSubscriptionRepositoryMessageDiagnose} {_methodBuildSubscriptionURLMessageDiagnose}, subscriptionURL: {subscriptionURL}");
             }
 
             return subscriptionURL;
@@ -116,7 +115,7 @@ namespace IOLApiClient.Operative.Subscription.Repository.Repositories.V2
             client.DefaultRequestHeaders.Add("Cache-Control", "no-cache");
             client.DefaultRequestHeaders.Add("Accept-Encoding", "gzip, deflate, br");
 
-            if (_logger.IsEnabled(LogEventLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
                 foreach (var defaultRequestHeader in client.DefaultRequestHeaders)
                 {
@@ -124,7 +123,7 @@ namespace IOLApiClient.Operative.Subscription.Repository.Repositories.V2
 
                     foreach (var value in values)
                     {
-                        _logger.Debug($"{_classSubscriptionRepositoryMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, default header assigned key: {defaultRequestHeader.Key}, value: {value}");
+                        _logger.LogDebug($"{_classSubscriptionRepositoryMessageDiagnose} {_methodBuildDefaultHeadersMessageDiagnose}, default header assigned key: {defaultRequestHeader.Key}, value: {value}");
                     }
                 }
             }

--- a/src/IOLApiClient.Titles.Repository.Abstractions/IOLApiClient.Titles.Repository.Abstractions.csproj
+++ b/src/IOLApiClient.Titles.Repository.Abstractions/IOLApiClient.Titles.Repository.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/IOLApiClient.Titles.Repository/IOLApiClient.Titles.Repository.csproj
+++ b/src/IOLApiClient.Titles.Repository/IOLApiClient.Titles.Repository.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Now we can use the assemblies for NET 5.0 and the each one of the assembly core will have Microsoft.Extension.Logging library instead of serilog.

Unit tests?: N

Functional tests: Existant ones

 
